### PR TITLE
Reuse styling for date cells

### DIFF
--- a/src/main/java/de/xm/jdbcexcel/DateCellWriter.java
+++ b/src/main/java/de/xm/jdbcexcel/DateCellWriter.java
@@ -8,11 +8,17 @@ import java.util.Date;
 
 public class DateCellWriter extends AbstractCellWriter<Date> {
 
+    private CellStyle dateCellStyle;
+
     @Override
     public void doWriteCell(Workbook workbook, Cell cell, Date cellValue) {
         cell.setCellValue(cellValue);
-        CellStyle dateCellStyle = workbook.createCellStyle();
-        dateCellStyle.setDataFormat(workbook.createDataFormat().getFormat("dd.MM.yyyy"));
+        synchronized (this) {
+            if (dateCellStyle == null) {
+                dateCellStyle = workbook.createCellStyle();
+                dateCellStyle.setDataFormat(workbook.createDataFormat().getFormat("dd.MM.yyyy"));
+            }
+        }
         cell.setCellStyle(dateCellStyle);
     }
 


### PR DESCRIPTION
Reuse cellstyle for date cells to avoid
problems when creating large excel sheets

This fixes isse #21 