### PR TITLE
Downgrade gradle cause release problems with 6.x

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Nov 10 18:43:55 CET 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+#Fri Mar 15 19:26:50 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
There are issues when publishing releases to
repositories when using gradle version greater than
5.x. Cause gradle 6 is not required this commit uses
the 5.x distribution as gradle wrapper.