### PR TITLE
Clear date cell for different workbook

### DIFF
--- a/src/main/java/de/xm/jdbcexcel/DateCellWriter.java
+++ b/src/main/java/de/xm/jdbcexcel/DateCellWriter.java
@@ -4,22 +4,34 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Workbook;
 
+import java.lang.ref.WeakReference;
 import java.util.Date;
 
 public class DateCellWriter extends AbstractCellWriter<Date> {
 
+    private WeakReference<Workbook> workbookWeakReference;
     private CellStyle dateCellStyle;
 
     @Override
     public void doWriteCell(Workbook workbook, Cell cell, Date cellValue) {
         cell.setCellValue(cellValue);
         synchronized (this) {
-            if (dateCellStyle == null) {
+            if (dateCellStyle == null || workbookWeakReference == null || workbookWeakReference.get() != workbook) {
+                clearOldReference();
                 dateCellStyle = workbook.createCellStyle();
                 dateCellStyle.setDataFormat(workbook.createDataFormat().getFormat("dd.MM.yyyy"));
+                workbookWeakReference = new WeakReference<>(workbook);
             }
         }
         cell.setCellStyle(dateCellStyle);
+    }
+
+    private void clearOldReference() {
+        dateCellStyle = null;
+        if (workbookWeakReference != null) {
+            workbookWeakReference.clear();
+            workbookWeakReference = null;
+        }
     }
 
 }


### PR DESCRIPTION
CellStyle must be cleared if using another
workbook. The cellstyle is cleard if the
reference of the workbook has changed cause
you must not use the same cell style for a
different workbook.